### PR TITLE
TabBar 개선

### DIFF
--- a/src/components/TabBar/Tab.tsx
+++ b/src/components/TabBar/Tab.tsx
@@ -1,12 +1,12 @@
-import React, { forwardRef, useContext, useEffect, useState } from 'react'
-import styled from '@emotion/styled'
-import { getTypoStyle, Typography } from '../../styles/foundation/typo/typo'
-import { TabBarContext } from './TabBar'
+import React, { forwardRef, useContext, useEffect, useState } from "react";
+import styled from "@emotion/styled";
+import { getTypoStyle, Typography } from "../../styles/foundation/typo/typo";
+import { TabBarContext } from "./TabBar";
 
-export interface TabProps {
+export type TabProps = {
   value: string
-  selected: boolean
-}
+  selected?: boolean
+} & React.HTMLProps<HTMLButtonElement>
 
 export const TabBase = styled.button<TabProps>`
   height: 48px;
@@ -25,22 +25,24 @@ export const TabBase = styled.button<TabProps>`
 export const Tab = forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
   const { value, setValue } = useContext(TabBarContext) ?? {
     value: undefined,
-    setValue: () => {},
-  }
-  if (props.selected && value === undefined) setValue(props.value)
-  const [selected, setSelected] = useState(props.selected)
+    setValue: () => {
+    }
+  };
+  if (props.selected && value === undefined) setValue(props.value);
+  const [selected, setSelected] = useState(props.selected);
   const updateValue = () => {
-    setValue(props.value)
-    setSelected(true)
-  }
+    setValue(props.value);
+    setSelected(true);
+  };
 
   useEffect(() => {
-    setSelected(value === props.value)
-  }, [value, props.value])
+    setSelected(value === props.value);
+  }, [value, props.value]);
 
   return (
-    <TabBase ref={ref} value={props.value} selected={selected} onClick={updateValue}>
+    <TabBase ref={ref} value={props.value} selected={selected}
+             onClick={updateValue}>
       {props.children}
     </TabBase>
-  )
-})
+  );
+});

--- a/src/components/TabBar/Tab.tsx
+++ b/src/components/TabBar/Tab.tsx
@@ -12,15 +12,19 @@ export const TabBase = styled.button<TabProps>`
   height: 48px;
   background-color: ${({ theme }) => theme.color.bgElevated};
   ${getTypoStyle(Typography.Button2)};
-  color: ${({ selected, theme }) => (selected ? theme.color.bottomBarSelected : theme.color.bottomBarNormal)};
-  border-width: ${({ selected }) => (selected ? '0 0 2px' : '0')};
+  color: ${({
+              selected,
+              theme
+            }) => (selected ? theme.color.bottomBarSelected : theme.color.bottomBarNormal)};
+  border-width: ${({ selected }) => (selected ? "0 0 2px" : "0")};
+  padding: ${({ selected }) => (selected ? "2px 2px 0" : "9")};
   border-bottom-color: ${({ theme }) => theme.color.bottomBarSelected};
   box-sizing: border-box;
 
   &:active {
     background-color: ${({ theme }) => theme.color.buttonNormalPressed};
   }
-`
+`;
 
 export const Tab = forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
   const { value, setValue } = useContext(TabBarContext) ?? {

--- a/src/components/TabBar/TabBar.stories.tsx
+++ b/src/components/TabBar/TabBar.stories.tsx
@@ -1,44 +1,55 @@
-import React from 'react'
-import { ComponentMeta, ComponentStory } from '@storybook/react'
-import { TabBar } from './TabBar'
-import { Tab } from './Tab'
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { TabBar } from "./TabBar";
+import { Tab } from "./Tab";
 
 export default {
-  title: 'Component/TabBar',
+  title: "Component/TabBar",
   component: TabBar,
-  argTypes: {},
-} as ComponentMeta<typeof TabBar>
+  argTypes: {}
+} as ComponentMeta<typeof TabBar>;
 
 /** !! */
 const Template: ComponentStory<typeof TabBar> = (args) => (
-  <TabBar scrollable={args.scrollable} navigation={args.navigation} onChange={args.onChange}>
-    <Tab value="1" selected>
-      Tab 1
-    </Tab>
-    <Tab value="2">Tab 2</Tab>
-    <Tab value="3">Tab 3</Tab>
-    <Tab value="4">Tab 4</Tab>
-    <Tab value="5">Tab 5</Tab>
-    <Tab value="6">Tab 6</Tab>
-    <Tab value="7">Tab 7</Tab>
-    <Tab value="8">Tab 8</Tab>
-  </TabBar>
-)
+  <div
+    style={{
+      backgroundColor: "#c4c4c4eb",
+      width: "374px",
+      height: "200px",
+      paddingTop: "16px",
+      paddingBottom: "16px"
+    }}
+  >
+    <TabBar scrollable={args.scrollable} navigation={args.navigation}
+            onChange={args.onChange}>
+      <Tab value="1" selected>
+        Tab 1
+      </Tab>
+      <Tab value="2">Tab 2</Tab>
+      <Tab value="3">Tab 3</Tab>
+      <Tab value="4">Tab 4</Tab>
+      <Tab value="5">Tab 5</Tab>
+      <Tab value="6">Tab 6</Tab>
+      <Tab value="7">Tab 7</Tab>
+      <Tab value="8">Tab 8</Tab>
+    </TabBar>
+  </div>
+);
 
-export const Scrollable = Template.bind({})
+export const Scrollable = Template.bind({});
 Scrollable.args = {
   scrollable: true,
-  navigation: false,
-}
+  navigation: false
+};
 
-export const ScrollableNavigation = Template.bind({})
+export const ScrollableNavigation = Template.bind({});
 ScrollableNavigation.args = {
   scrollable: true,
-  navigation: true,
-}
+  navigation: true
+};
 
-export const Fixed = Template.bind({})
+export const Fixed = Template.bind({});
 Fixed.args = {
   scrollable: false,
-  navigation: false,
-}
+  navigation: false
+};

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -1,37 +1,56 @@
-import React, { createContext, forwardRef, useMemo, useRef, useState } from 'react'
-import styled from '@emotion/styled'
-import { ArrowLeftLineIcon, ArrowRightLineIcon } from '../../icons'
-import { Divider } from '../Divider/Divider'
-import { Tab, TabBase } from './Tab'
+import React, {
+  createContext,
+  forwardRef,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+import styled from "@emotion/styled";
+import { ArrowLeftLineIcon, ArrowRightLineIcon } from "../../icons";
+import { Divider } from "../Divider/Divider";
+import { TabBase } from "./Tab";
 
 export interface TabBarProps {
-  scrollable: boolean
-  navigation: boolean
-  children: React.ReactNode
-  value: string
-  onChange?: (id: string) => void
+  scrollable: boolean;
+  navigation: boolean;
+  children: React.ReactNode;
+  value?: string;
+  onChange?: (id: string) => void;
 }
 
 export interface TabBarState {
-  value: string | undefined
-  setValue: (id: string) => void
+  value: string | undefined;
+  setValue: (id: string) => void;
 }
 
-export const TabBarContext = createContext<TabBarState | undefined>(undefined)
+export const TabBarContext = createContext<TabBarState | undefined>(undefined);
 
-const TabBarNavigation = styled.button`
+const TabBarNavigation = styled.button<{ direction: "left" | "right" }>`
   width: 24px;
   height: 100%;
-  background-color: ${({ theme }) => theme.color.bgElevated};
+  background: ${({
+                   direction,
+                   theme
+                 }) => `linear-gradient(to ${direction}, rgba(0, 0, 0, 0), ${theme.color.bgElevated})`};
   color: ${({ theme }) => theme.color.buttonNormal};
   border: none;
+  top: 0;
 
-  &:active {
-    background-color: ${({ theme }) => theme.color.buttonNormalPressed};
+  ${({ direction }) => direction === "left" ? "left: 0;" : "right: 0;"}
+  ${({ disabled, theme }) => disabled ? "" : `&:active {
+    background-color: ${theme.color.buttonNormalPressed};
+  }`}
+  svg {
+    fill: ${({
+               disabled,
+               theme
+             }) => disabled ? theme.color.buttonDisabled : theme.color.buttonNormal};
   }
-`
+`;
 
 const TabList = styled.div<{ scrollable: boolean }>`
+  background-color: ${({ theme }) => theme.color.bgElevated};
+  padding: 0 24px;
   display: flex;
   overflow-x: ${({ scrollable }) => (scrollable ? 'scroll' : 'visible')};
   -ms-overflow-style: none;
@@ -42,58 +61,62 @@ const TabList = styled.div<{ scrollable: boolean }>`
   }
 
   ${TabBase} {
-    min-width: ${({ scrollable }) => (scrollable ? '88px' : 'auto')};
+    min-width: ${({ scrollable }) => (scrollable ? "88px" : "auto")};
   }
-`
+`;
 
 const TabBarWrapper = styled.div<{ scrollable: boolean; navigation: boolean }>`
-  display: flex;
-  align-items: center;
+  position: relative;
 
   ${TabBarNavigation} {
-    flex: 0 1 auto;
-    display: ${({ scrollable, navigation }) => (scrollable && navigation ? 'block' : 'none')};
+    position: absolute;
+    display: ${({
+                  scrollable,
+                  navigation
+                }) => (scrollable && navigation ? "block" : "none")};
   }
-`
+`;
 
 export interface TabBarProviderProps {
-  children: React.ReactNode
-  onChange: (id: string) => void
+  children: React.ReactNode;
+  onChange: (id: string) => void;
 }
 
 function TabBarProvider({ children, onChange }: TabBarProviderProps) {
-  const [value, setValue] = useState<string | undefined>(undefined)
+  const [value, setValue] = useState<string | undefined>(undefined);
   const changeValue = (newValue: string) => {
-    setValue(newValue)
-    onChange(newValue)
-  }
+    setValue(newValue);
+    onChange(newValue);
+  };
 
   const state = useMemo(
     () => ({
       value,
-      setValue: changeValue,
+      setValue: changeValue
     }),
-    [value],
-  )
+    [value]
+  );
 
-  return <TabBarContext.Provider value={state}>{children}</TabBarContext.Provider>
+  return <TabBarContext.Provider
+    value={state}>{children}</TabBarContext.Provider>;
 }
 
 export const TabBar = forwardRef<HTMLDivElement, TabBarProps>((props, ref) => {
   const listRef = useRef<HTMLDivElement>(null)
 
   const onWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+    event.preventDefault();
     if (listRef?.current) {
       event.preventDefault()
       listRef.current.scrollLeft += event.deltaY
     }
-  }
+  };
 
   const scrollPage = (isPositive: boolean) => {
     if (listRef?.current) {
-      const pos = listRef.current.scrollLeft
-      const cWidth = listRef.current.clientWidth
-      const sWidth = listRef.current.scrollWidth
+      const pos = listRef.current.scrollLeft;
+      const cWidth = listRef.current.clientWidth;
+      const sWidth = listRef.current.scrollWidth;
       if (isPositive) {
         const newPos = pos + cWidth
         listRef.current.scrollLeft = newPos > sWidth ? sWidth - cWidth : newPos
@@ -102,7 +125,7 @@ export const TabBar = forwardRef<HTMLDivElement, TabBarProps>((props, ref) => {
         listRef.current.scrollLeft = newPos < 0 ? 0 : newPos
       }
     }
-  }
+  };
 
   return (
     <TabBarProvider onChange={props.onChange ?? (() => {})}>
@@ -117,7 +140,7 @@ export const TabBar = forwardRef<HTMLDivElement, TabBarProps>((props, ref) => {
           <ArrowRightLineIcon />
         </TabBarNavigation>
       </TabBarWrapper>
-      <Divider thickness="thin" direction="horizontal" />
+      <Divider thickness="thin" direction="horizontal" style={{ margin: 0 }} />
     </TabBarProvider>
-  )
-})
+  );
+});

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -25,7 +25,7 @@ export interface TabBarState {
 
 export const TabBarContext = createContext<TabBarState | undefined>(undefined);
 
-const TabBarNavigation = styled.button<{ direction: "left" | "right" }>`
+const TabBarNavigation = styled.button<{ direction: "left" | "right"; disabled: boolean }>`
   width: 24px;
   height: 100%;
   background: ${({
@@ -109,12 +109,13 @@ export const TabBar = forwardRef<HTMLDivElement, TabBarProps>((props, ref) => {
   const onWheel = (event: React.WheelEvent<HTMLDivElement>) => {
     event.preventDefault();
     if (listRef?.current) {
+      const cWidth = listRef.current.clientWidth;
       const sWidth = listRef.current.scrollWidth;
       listRef.current.scrollLeft += event.deltaY;
-      if (sWidth >= listRef.current.scrollLeft) {
-        setIsOnEnd(true);
-        setIsOnStart(false);
-      }
+      if (isOnEnd !== listRef.current.scrollLeft >= sWidth - cWidth)
+        setIsOnEnd(listRef.current.scrollLeft >= sWidth - cWidth);
+      if (isOnStart !== listRef.current.scrollLeft <= 0)
+        setIsOnStart(listRef.current.scrollLeft <= 0);
     }
   };
 
@@ -126,8 +127,9 @@ export const TabBar = forwardRef<HTMLDivElement, TabBarProps>((props, ref) => {
       if (isPositive) {
         const newPos = pos + 88;
         if (isOnStart) setIsOnStart(false);
-        if (newPos > sWidth) {
-          setIsOnStart(true);
+        console.log(newPos, sWidth);
+        if (newPos >= sWidth - cWidth) {
+          setIsOnEnd(true);
           listRef.current.scrollLeft = sWidth - cWidth;
           return;
         }
@@ -135,7 +137,7 @@ export const TabBar = forwardRef<HTMLDivElement, TabBarProps>((props, ref) => {
       } else {
         const newPos = pos - 88;
         if (isOnEnd) setIsOnEnd(false);
-        if (newPos < 0) {
+        if (newPos <= 0) {
           setIsOnStart(true);
           listRef.current.scrollLeft = 0;
           return;
@@ -150,14 +152,14 @@ export const TabBar = forwardRef<HTMLDivElement, TabBarProps>((props, ref) => {
     })}>
       <TabBarWrapper scrollable={props.scrollable} navigation={props.navigation}
                      ref={ref}>
-        <TabBarNavigation direction="left"
+        <TabBarNavigation disabled={isOnStart} direction="left"
                           onClick={() => scrollPage(false)}>
           <ArrowLeftLineIcon />
         </TabBarNavigation>
         <TabList ref={listRef} scrollable={props.scrollable} onWheel={onWheel}>
           {props.children}
         </TabList>
-        <TabBarNavigation direction="right"
+        <TabBarNavigation disabled={isOnEnd} direction="right"
                           onClick={() => scrollPage(true)}>
           <ArrowRightLineIcon />
         </TabBarNavigation>


### PR DESCRIPTION
- 탭 리스트 위에 네비게이션 버튼이 떠 있도록 수정
- 가독성을 위해 탭 리스트 양 옆에 네비게이션 버튼의 크기만큼 padding 줌
- 네비게이션 버튼에 그라디언트 부여
- 리스트의 양 끝에 도달하면 네비게이션 버튼이 비활성화 되도록 개선
- 데스크톱에서 탭 리스트를 스크롤하면 부모 엘리먼트도 스크롤되는 현상 수정
- Divider 의 margin 삭제