### PR TITLE
Add Tooltip.stories.tsx, Change Subheader TypoStyle

### DIFF
--- a/src/components/List/List.styles.tsx
+++ b/src/components/List/List.styles.tsx
@@ -15,9 +15,9 @@ export const SubHeader = styled.div`
   padding: 0 20px;
   width: 100%;
   align-items: center;
-  ${getTypoStyle(Typography.Body1)};
   color: ${({ theme }) => theme.color.textSecondary};
   height: 48px;
+  ${getTypoStyle(Typography.Subtitle3)};
 `
 
 export const ListItems = styled.div`

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { Tooltip } from './Tooltip'
+
+export default {
+  title: 'Component/Tooltip',
+  component: Tooltip,
+  argTypes: {},
+} as ComponentMeta<typeof Tooltip>
+
+const Template: ComponentStory<typeof Tooltip> = (args) => (
+  <div
+    style={{
+      backgroundColor: '#c4c4c4eb',
+      width: '374px',
+      height: '400px',
+      paddingTop: '16px',
+      paddingBottom: '16px',
+    }}
+  >
+    <Tooltip {...args} />
+  </div>
+)
+
+export const Primary = Template.bind({})
+Primary.args = {
+  arrowPosition: 'top',
+  arrowAlign: 'start',
+  children: '홈에서 실시간 피드를 확인해보세요!',
+}


### PR DESCRIPTION
1. 5월9일에 `Lime` `fix/list` `브런치 Merge` 과정 중 `Tooltip.stories.tsx`가 삭제 한 채로 머지 되었음
2. 이에 대해서 이전에 작성 되어있던 `Tooltip.stories.tsx` 를 다시 추가 하였습니다.

------

`지금 봤는데 제목은 subtitle3 (14, Medium) 이에요! f12 찍어보니까 지금은 15인듯 싶습니닷` 에 대한 Font Typo Style 수정 입니다.

- `List.styles.tsx` 의 `SubHeader` 에서 `Typography.Body `-> `Typography.Subtitle3` 로 변경 하였습니다